### PR TITLE
Add link to explanation of "Egyptian brackets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,7 +1304,7 @@ self.productsRequest = [[SKProductsRequest alloc]
 
 ### Brackets
 
-Use Egyptian brackets for:
+Use [Egyptian brackets](https://en.wikipedia.org/wiki/Indent_style#K.26R_style) for:
 
 * control structures (if-else, for, switch)
 


### PR DESCRIPTION
I linked to the K&R section in Wikipedia's [Indent Style](https://en.wikipedia.org/wiki/Indent_style) page, as I could not find a good reference for the exact "Egyptian style" term.

[Jeff Atwood's post](http://blog.codinghorror.com/new-programming-jargon/) provides a good description, but defines no anchors, making it AFAIK impossible to link directly to the relevant bit of information.
